### PR TITLE
refactor: minor UI updates

### DIFF
--- a/components/desktopnav.tsx
+++ b/components/desktopnav.tsx
@@ -112,7 +112,7 @@ const DesktopNav = ({
         </div>
       </div>
 
-      <div className="flex flex-1 flex-col dark:bg-[#141414] md:pl-64">
+      <div className="flex flex-1 flex-col dark:bg-[#141414] md:pl-64 lg:h-screen">
         <div className="sticky top-0 z-10 pl-1 pt-1 sm:pl-3 sm:pt-3 md:hidden">
           <button
             type="button"

--- a/components/desktopnav.tsx
+++ b/components/desktopnav.tsx
@@ -90,7 +90,7 @@ const DesktopNav = ({
                 </Link>
               ))}
             </nav>
-            <div className="mx-2 flex items-center space-x-2 text-white">
+            <div className="mt-2 mx-2 flex items-center space-x-2 text-white">
               {!user ? (
                 <div
                   onClick={() => setShowLoginModal(true)}

--- a/components/inputs/draganddrop.tsx
+++ b/components/inputs/draganddrop.tsx
@@ -115,7 +115,7 @@ export const DragAndDrop = React.memo(
       };
     }, [handleDrag, handleDragIn, handleDragOut, handleDrop]);
 
-    return <div ref={dragAndDropRef}>{props.children}</div>;
+    return <div className="h-full" ref={dragAndDropRef}>{props.children}</div>;
   }
 );
 

--- a/components/mobilenav.tsx
+++ b/components/mobilenav.tsx
@@ -143,7 +143,7 @@ const MobileNav = ({
                     </Link>
                   ))}
                 </nav>
-                <div className="mx-2 flex items-center space-x-2 text-white">
+                <div className="mt-[4px] mx-2 flex items-center space-x-2 text-white">
                   {!user ? (
                     <div
                       onClick={() => {

--- a/components/sidebarlayout.tsx
+++ b/components/sidebarlayout.tsx
@@ -519,8 +519,9 @@ const SidebarLayout = ({
             animate={{ y: 0, opacity: 1 }}
             exit={{ y: -10, opacity: 0 }}
             transition={{ duration: 0.3 }}
+            className="h-full"
           >
-            <div className="py-6">{children}</div>
+            <div className="py-6 h-full">{children}</div>
           </motion.div>
         </AnimatePresence>
       </DesktopNav>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -174,7 +174,7 @@ const Home: NextPage = () => {
         <div className="px-4 sm:px-6 md:px-8 lg:px-10 xl:px-12 2xl:px-14">
           <div className="grid gap-4">
             <div>
-              <div className="flex h-[33vh] flex-col justify-center rounded-lg border border-gray-300 py-4  px-5 text-center  dark:border-[#2A2A2A] dark:bg-[#191919]">
+              <div className="flex flex-col justify-center rounded-lg border border-gray-300 py-4  px-5 text-center  dark:border-[#2A2A2A] dark:bg-[#191919] lg:h-[33vh]">
                 <div className="items-center space-y-3">
                   <div className="items-center">
                     <Image
@@ -222,7 +222,7 @@ const Home: NextPage = () => {
                   </div>
                 </div>
               </div>
-              <div className="flex h-[33vh] flex-col justify-center rounded-lg border border-gray-300 py-4  px-5 text-center  dark:border-[#2A2A2A] dark:bg-[#191919]">
+              <div className="flex flex-col justify-center rounded-lg border border-gray-300 py-4  px-5 text-center  dark:border-[#2A2A2A] dark:bg-[#191919]">
                 <div className="space-y-6">
                   <div className="text-md justify-center font-semibold text-gray-900 dark:text-white">
                     How to use: expandable card
@@ -246,7 +246,7 @@ const Home: NextPage = () => {
                 onDragStateChange={onDragStateChange}
                 onFilesDrop={onFilesDrop}
               >
-                <div className="min-w-0 h-[25vh] flex flex-col justify-center rounded-lg border border-gray-300 py-4  px-5 text-center  dark:border-[#2A2A2A] dark:bg-[#191919]">
+                <div className="min-w-0 flex flex-col justify-center rounded-lg border border-gray-300 py-4  px-5 text-center  dark:border-[#2A2A2A] dark:bg-[#191919] lg:h-[25vh]">
                   <label className="flex h-full w-full flex-grow items-center justify-center space-x-3">
                     <PlusIcon
                       className="h-10 w-10 text-gray-400 group-hover:text-gray-500"

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -171,8 +171,8 @@ const Home: NextPage = () => {
         sidebarOpen={sidebarOpen}
         setSidebarOpen={setSidebarOpen}
       >
-        <div className="px-4 sm:px-6 md:px-8 lg:px-10 xl:px-12 2xl:px-14">
-          <div className="grid gap-4 md:h-screen">
+        <div className="px-4 sm:px-6 md:px-8 lg:px-10 xl:px-12 2xl:px-14 h-full">
+          <div className="grid gap-4 min-h-full">
             <div className="h-full">
               <div className="flex flex-col justify-center rounded-lg border border-gray-300 py-4  px-5 text-center  dark:border-[#2A2A2A] dark:bg-[#191919] h-full">
                 <div className="items-center space-y-3">
@@ -202,7 +202,7 @@ const Home: NextPage = () => {
                 </div>
               </div>
             </div>
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <div className="grid grid-cols-1 gap-4 h-full md:grid-cols-2">
               <div className="flex flex-col justify-center rounded-lg border border-gray-300 py-4  px-5 text-center  dark:border-[#2A2A2A] dark:bg-[#191919]">
                 <div className="space-y-6">
                   <div className="text-md justify-center font-semibold text-gray-900 dark:text-white">
@@ -222,7 +222,7 @@ const Home: NextPage = () => {
                   </div>
                 </div>
               </div>
-              <div className="flex flex-col justify-center rounded-lg border border-gray-300 py-4  px-5 text-center  dark:border-[#2A2A2A] dark:bg-[#191919]">
+              <div className="flex flex-col justify-center rounded-lg border border-gray-300 py-4  px-5 text-center  dark:border-[#2A2A2A] dark:bg-[#191919] h-full">
                 <div className="space-y-6">
                   <div className="text-md justify-center font-semibold text-gray-900 dark:text-white">
                     How to use: expandable card

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -172,9 +172,9 @@ const Home: NextPage = () => {
         setSidebarOpen={setSidebarOpen}
       >
         <div className="px-4 sm:px-6 md:px-8 lg:px-10 xl:px-12 2xl:px-14">
-          <div className="grid gap-4">
-            <div>
-              <div className="flex flex-col justify-center rounded-lg border border-gray-300 py-4  px-5 text-center  dark:border-[#2A2A2A] dark:bg-[#191919] lg:h-[33vh]">
+          <div className="grid gap-4 md:h-screen">
+            <div className="h-full">
+              <div className="flex flex-col justify-center rounded-lg border border-gray-300 py-4  px-5 text-center  dark:border-[#2A2A2A] dark:bg-[#191919] h-full">
                 <div className="items-center space-y-3">
                   <div className="items-center">
                     <Image
@@ -241,49 +241,47 @@ const Home: NextPage = () => {
                 </div>
               </div>
             </div>
-            <div className="hover:cursor-pointer">
-              <DragAndDrop
-                onDragStateChange={onDragStateChange}
-                onFilesDrop={onFilesDrop}
-              >
-                <div className="min-w-0 flex flex-col justify-center rounded-lg border border-gray-300 py-4  px-5 text-center  dark:border-[#2A2A2A] dark:bg-[#191919] lg:h-[25vh]">
-                  <label className="flex h-full w-full flex-grow items-center justify-center space-x-3">
-                    <PlusIcon
-                      className="h-10 w-10 text-gray-400 group-hover:text-gray-500"
-                      aria-hidden="true"
-                    />
+            <DragAndDrop
+              onDragStateChange={onDragStateChange}
+              onFilesDrop={onFilesDrop}
+            >
+              <div className="min-w-0 flex flex-col justify-center rounded-lg border border-gray-300 py-4  px-5 text-center  dark:border-[#2A2A2A] dark:bg-[#191919] h-full">
+                <label className="flex h-full w-full flex-grow items-center justify-center space-x-3 cursor-pointer">
+                  <PlusIcon
+                    className="h-10 w-10 text-gray-400 group-hover:text-gray-500"
+                    aria-hidden="true"
+                  />
 
-                    <div>
-                      <p className="text-sm text-gray-400 group-hover:text-gray-500">
-                        Drag your Stardew Valley save here, or click to upload.
-                      </p>
-                      <br />
+                  <div>
+                    <p className="text-sm text-gray-400 group-hover:text-gray-500">
+                      Drag your Stardew Valley save here, or click to upload.
+                    </p>
+                    <br />
 
-                      <p className="text-sm text-gray-400 group-hover:text-gray-500">
-                        Need help finding your save? Saves usually look like
-                        this: <code>Jack_0120902</code>
-                      </p>
-                      <p className="text-sm text-gray-400 group-hover:text-gray-500">
-                        <span className="font-bold">Windows: </span>
-                        %AppData%\StardewValley\Saves\
-                      </p>
-                      <p className="text-sm text-gray-400 group-hover:text-gray-500">
-                        <span className="font-bold">macOS & Linux: </span>
-                        ~/.config/StardewValley/Saves/
-                      </p>
-                    </div>
+                    <p className="text-sm text-gray-400 group-hover:text-gray-500">
+                      Need help finding your save? Saves usually look like
+                      this: <code>Jack_0120902</code>
+                    </p>
+                    <p className="text-sm text-gray-400 group-hover:text-gray-500">
+                      <span className="font-bold">Windows: </span>
+                      %AppData%\StardewValley\Saves\
+                    </p>
+                    <p className="text-sm text-gray-400 group-hover:text-gray-500">
+                      <span className="font-bold">macOS & Linux: </span>
+                      ~/.config/StardewValley/Saves/
+                    </p>
+                  </div>
 
-                    <input
-                      type="file"
-                      className="hidden"
-                      onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                        handleChange(e)
-                      }
-                    />
-                  </label>
-                </div>
-              </DragAndDrop>
-            </div>
+                  <input
+                    type="file"
+                    className="hidden hover:cursor-pointer"
+                    onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                      handleChange(e)
+                    }
+                  />
+                </label>
+              </div>
+            </DragAndDrop>
           </div>
         </div>
       </SidebarLayout>


### PR DESCRIPTION
Hello, I have noticed that the tutorial components on the home page are overflowing from the parent when I zoom in or use a smaller resolution. This is because of the fixed height that has been defined.

To address this issue, I have set the height specifically for devices with a screen height of 1024px or larger. Additionally, I have added a margin to the `Login with Discord` navigation to ensure it looks consistent with other navigation items.