### PR TITLE
Remove Haley as use of Prismatic Shard

### DIFF
--- a/src/data/artifacts.json
+++ b/src/data/artifacts.json
@@ -597,7 +597,6 @@
       ],
       "used_in": [
         "Villagers",
-        "Haley",
         "Galaxy Sword",
         "the Desert",
         "Dark Shrine of Selfishness",


### PR DESCRIPTION
Haley is the only Villager that [hates](https://stardewvalleywiki.com/Prismatic_Shard#Gifting) (rather than loves) the Prismatic Shard