### PR TITLE
Rounding skills progress bar

### DIFF
--- a/src/pages/skills.tsx
+++ b/src/pages/skills.tsx
@@ -116,7 +116,7 @@ export default function SkillsMasteryPowers() {
         percentage:
           currentLevel >= 10
             ? 100
-            : (currentExperience / nextLevelExperience) * 100,
+            : Math.floor((currentExperience / nextLevelExperience) * 100),
         experiencePointsRemaining: Math.max(
           nextLevelExperience - currentExperience,
           0,


### PR DESCRIPTION
Hi!

Just noticed the skill progression value was off. I just rounded it down, since the exact decimal value of the progress doesn't feel that important.
I hope this contribution is of some use.

Before:
![before](https://github.com/communitycenter/stardew.app/assets/18200593/018866f6-fac0-4865-8186-8a4fa0fe0ab6)

After:
![after](https://github.com/communitycenter/stardew.app/assets/18200593/8d7a2d50-49c2-4fb9-a4b7-76eda599554d)

