### PR TITLE
Use backslashes for Windows path in upload dialog

### DIFF
--- a/src/components/dialogs/upload-dialog.tsx
+++ b/src/components/dialogs/upload-dialog.tsx
@@ -118,7 +118,7 @@ export const UploadDialog = ({ open, setOpen }: Props) => {
           <Button
             variant={"secondary"}
             onClick={() => {
-              navigator.clipboard.writeText("%appdata%/StardewValley/Saves");
+              navigator.clipboard.writeText("%appdata%\\StardewValley\\Saves");
               toast.info("Copied the folder location to your clipboard!", {
                 description:
                   "To go to this folder, press Windows key + R and paste the path. Your save will be located there.",


### PR DESCRIPTION
While the Run dialog does accept either type of slash, there are other ways to open folders which are less forgiving -- I tend to just paste into the Windows 10 start menu directly, but that only accepts the canonical backslash as a separator.