### PR TITLE
Slight code refactor in "Skills" page

### DIFF
--- a/src/pages/skills.tsx
+++ b/src/pages/skills.tsx
@@ -225,7 +225,7 @@ export default function SkillsMasteryPowers() {
             <section className="space-y-3">
               <AccordionItem value="item-1">
                 <AccordionTrigger className="ml-1 pt-0 text-xl font-semibold text-gray-900 dark:text-white">
-                  Skill Achievements
+                  Skills
                 </AccordionTrigger>
                 <AccordionContent>
                   <div className="space-y-3">

--- a/src/pages/skills.tsx
+++ b/src/pages/skills.tsx
@@ -49,7 +49,6 @@ export default function SkillsMasteryPowers() {
 
     if (activePlayer) {
       const skills = new Set(["Singular Talent", "Master Of The Five Ways"]);
-      const quests = new Set(["Gofer", "A Big Help"]);
       const powers = new Set(["Well-Read"]);
 
       if (skills.has(name)) {
@@ -57,14 +56,6 @@ export default function SkillsMasteryPowers() {
         if (maxLevelCount >= reqs[name]) completed = true;
         else {
           additionalDescription = ` - ${reqs[name] - maxLevelCount} left`;
-        }
-      } else if (quests.has(name)) {
-        // use general.questsCompleted and compare to reqs
-        const questsCompleted = activePlayer.general?.questsCompleted ?? 0;
-
-        if (questsCompleted >= reqs[name]) completed = true;
-        else {
-          additionalDescription = ` - ${reqs[name] - questsCompleted} left`;
         }
       } else if (powers.has(name)) {
         if (playerPowers.size >= reqs[name]) completed = true;

--- a/src/pages/skills.tsx
+++ b/src/pages/skills.tsx
@@ -58,6 +58,7 @@ export default function SkillsMasteryPowers() {
           additionalDescription = ` - ${reqs[name] - maxLevelCount} left`;
         }
       } else if (powers.has(name)) {
+        // use the size of playerPowers and compare to reqs
         if (playerPowers.size >= reqs[name]) completed = true;
         else {
           additionalDescription = ` - ${reqs[name] - playerPowers.size} left`;


### PR DESCRIPTION
This PR:
- Removes a part of the code that deals with quests (since it is now in the Farmer page, I presume it is no longer needed here);
- Adds a comment;
- Changes the AccordionTrigger's text content from "Skill Achievements" to "Skills", following the project's apparent rule of naming them according to whether the section tracks only achievements or not (in the case of Skills, it also tracks the skills themselves, not just the achievements; a similar example is the "Stardrops" section).