### PR TITLE
Correct search input placeholder

### DIFF
--- a/src/pages/shipping.tsx
+++ b/src/pages/shipping.tsx
@@ -249,7 +249,7 @@ export default function Shipping() {
                 <Command className="max-w-xs border border-b-0 dark:border-neutral-800">
                   <CommandInput
                     onValueChange={(v) => setSearch(v)}
-                    placeholder="Search Recipes"
+                    placeholder="Search Items"
                   />
                 </Command>
               </div>


### PR DESCRIPTION
Changes the placeholder from "Search Recipes" to "Search Items" as the shipping section is not about recipes.